### PR TITLE
Allow redefinition of where logging goes

### DIFF
--- a/Artnet/Common.h
+++ b/Artnet/Common.h
@@ -85,12 +85,6 @@ struct Destination
     uint8_t universe;
 };
 
-class NoPrint : public Print {
-    size_t write(uint8_t) {
-        return 0;
-    }
-};
-NoPrint NoLog;
 
 inline bool operator<(const Destination &rhs, const Destination &lhs)
 {

--- a/Artnet/Common.h
+++ b/Artnet/Common.h
@@ -85,6 +85,13 @@ struct Destination
     uint8_t universe;
 };
 
+class NoPrint : public Print {
+    size_t write(uint8_t) {
+        return 0;
+    }
+};
+NoPrint NoLog;
+
 inline bool operator<(const Destination &rhs, const Destination &lhs)
 {
     if (rhs.ip < lhs.ip) {

--- a/Artnet/Receiver.h
+++ b/Artnet/Receiver.h
@@ -303,11 +303,7 @@ protected:
         this->stream = &s;
     }
 
-#if defined(NO_GLOBAL_INSTANCES) || defined(NO_GLOBAL_SERIAL)
-    Print* log = nullptr; // No Serial -> no output
-#else
-    Print* log = &Serial; // Use Serial by default
-#endif
+    Print* log = &NoLog;
 
 private:
     bool checkID() const

--- a/Artnet/Receiver.h
+++ b/Artnet/Receiver.h
@@ -24,8 +24,6 @@ class Receiver_
     art_trigger::CallbackType callback_art_trigger;
     ArtPollReplyConfig art_poll_reply_config;
 
-    bool b_verbose {false};
-
 public:
 #if ARX_HAVE_LIBSTDCPLUSPLUS >= 201103L  // Have libstdc++11
 #else
@@ -48,18 +46,14 @@ public:
         }
 
         if (size > PACKET_SIZE) {
-            if (this->b_verbose) {
-                log->print(F("Packet size is unexpectedly too large: "));
-                log->println(size);
-            }
+            log->print(F("Packet size is unexpectedly too large: "));
+            log->println(size);
             size = PACKET_SIZE;
         }
         this->stream->read(this->packet.data(), size);
 
         if (!checkID()) {
-            if (this->b_verbose) {
-                log->println(F("Packet ID is not Art-Net"));
-            }
+            log->println(F("Packet ID is not Art-Net"));
             return OpCode::ParseFailed;
         }
 
@@ -120,10 +114,8 @@ public:
                 break;
             }
             default: {
-                if (this->b_verbose) {
-                    log->print(F("Unsupported OpCode: "));
-                    log->println(this->getOpCode(), HEX);
-                }
+                log->print(F("Unsupported OpCode: "));
+                log->println(this->getOpCode(), HEX);
                 op_code = OpCode::Unsupported;
                 break;
             }
@@ -139,21 +131,15 @@ public:
     -> std::enable_if_t<arx::is_callable<Fn>::value>
     {
         if (net > 0x7F) {
-            if (this->b_verbose) {
-                log->println(F("net should be less than 0x7F"));
-            }
+            log->println(F("net should be less than 0x7F"));
             return;
         }
         if (subnet > 0xF) {
-            if (this->b_verbose) {
-                log->println(F("subnet should be less than 0xF"));
-            }
+            log->println(F("subnet should be less than 0xF"));
             return;
         }
         if (universe > 0xF) {
-            if (this->b_verbose) {
-                log->println(F("universe should be less than 0xF"));
-            }
+            log->println(F("universe should be less than 0xF"));
             return;
         }
         uint16_t u = ((uint16_t)net << 8) | ((uint16_t)subnet << 4) | (uint16_t)universe;
@@ -286,11 +272,6 @@ public:
         this->art_poll_reply_config.short_name = short_name;
         this->art_poll_reply_config.long_name = long_name;
         this->art_poll_reply_config.node_report = node_report;
-    }
-
-    void verbose(bool b)
-    {
-        this->b_verbose = b;
     }
 
     void logOutputTo(Print* dest) {

--- a/Artnet/Receiver.h
+++ b/Artnet/Receiver.h
@@ -49,8 +49,8 @@ public:
 
         if (size > PACKET_SIZE) {
             if (this->b_verbose) {
-                Serial.print(F("Packet size is unexpectedly too large: "));
-                Serial.println(size);
+                log->print(F("Packet size is unexpectedly too large: "));
+                log->println(size);
             }
             size = PACKET_SIZE;
         }
@@ -58,7 +58,7 @@ public:
 
         if (!checkID()) {
             if (this->b_verbose) {
-                Serial.println(F("Packet ID is not Art-Net"));
+                log->println(F("Packet ID is not Art-Net"));
             }
             return OpCode::ParseFailed;
         }
@@ -121,8 +121,8 @@ public:
             }
             default: {
                 if (this->b_verbose) {
-                    Serial.print(F("Unsupported OpCode: "));
-                    Serial.println(this->getOpCode(), HEX);
+                    log->print(F("Unsupported OpCode: "));
+                    log->println(this->getOpCode(), HEX);
                 }
                 op_code = OpCode::Unsupported;
                 break;
@@ -140,19 +140,19 @@ public:
     {
         if (net > 0x7F) {
             if (this->b_verbose) {
-                Serial.println(F("net should be less than 0x7F"));
+                log->println(F("net should be less than 0x7F"));
             }
             return;
         }
         if (subnet > 0xF) {
             if (this->b_verbose) {
-                Serial.println(F("subnet should be less than 0xF"));
+                log->println(F("subnet should be less than 0xF"));
             }
             return;
         }
         if (universe > 0xF) {
             if (this->b_verbose) {
-                Serial.println(F("universe should be less than 0xF"));
+                log->println(F("universe should be less than 0xF"));
             }
             return;
         }
@@ -253,11 +253,11 @@ public:
                 n = num;
             } else {
                 n = size / 3;
-                Serial.println(F("WARN: ArtNet packet size is less than requested LED numbers to forward"));
-                Serial.print(F("      requested: "));
-                Serial.print(num * 3);
-                Serial.print(F("      received : "));
-                Serial.println(size);
+                log->println(F("WARN: ArtNet packet size is less than requested LED numbers to forward"));
+                log->print(F("      requested: "));
+                log->print(num * 3);
+                log->print(F("      received : "));
+                log->println(size);
             }
             for (size_t pixel = 0; pixel < n; ++pixel) {
                 size_t idx = pixel * 3;
@@ -293,11 +293,21 @@ public:
         this->b_verbose = b;
     }
 
+    void logOutputTo(Print* dest) {
+        log = dest;
+    }
+
 protected:
     void attach(S& s)
     {
         this->stream = &s;
     }
+
+#if defined(NO_GLOBAL_INSTANCES) || defined(NO_GLOBAL_SERIAL)
+    Print* log = nullptr; // No Serial -> no output
+#else
+    Print* log = &Serial; // Use Serial by default
+#endif
 
 private:
     bool checkID() const

--- a/README.md
+++ b/README.md
@@ -355,8 +355,8 @@ void forwardArtDmxDataToFastLED(uint16_t universe, CRGB* leds, uint16_t num);
 // set information for artpollreply
 // https://art-net.org.uk/how-it-works/discovery-packets/artpollreply/
 void setArtPollReplyConfig(uint16_t oem, uint16_t esta_man, uint8_t status1, uint8_t status2, const String &short_name, const String &long_name, const String &node_report);
-// others
-void verbose(bool b);
+// Set where debug output should go (default is nowhere)
+void logOutputTo(Print*);
 ```
 
 ### Note

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ void forwardArtDmxDataToFastLED(uint16_t universe, CRGB* leds, uint16_t num);
 // https://art-net.org.uk/how-it-works/discovery-packets/artpollreply/
 void setArtPollReplyConfig(uint16_t oem, uint16_t esta_man, uint8_t status1, uint8_t status2, const String &short_name, const String &long_name, const String &node_report);
 // Set where debug output should go (default is nowhere)
-void logOutputTo(Print*);
+void setLogger(Print*);
 ```
 
 ### Note


### PR DESCRIPTION
Sometimes I want to log to places other than `Serial` (when I have a display connected, or when my adapter is attached to `Serial1` for example)

Also adds guards so things don't break when the user disables `Serial` 