### PR TITLE
Make art_poll_reply_config publicly accessible

### DIFF
--- a/Artnet/Receiver.h
+++ b/Artnet/Receiver.h
@@ -22,11 +22,13 @@ class Receiver_
     art_nzs::CallbackMap callback_art_nzs_universes;
     art_sync::CallbackType callback_art_sync;
     art_trigger::CallbackType callback_art_trigger;
-    ArtPollReplyConfig art_poll_reply_config;
 
     bool b_verbose {false};
 
 public:
+    ArtPollReplyConfig art_poll_reply_config;
+
+
 #if ARX_HAVE_LIBSTDCPLUSPLUS >= 201103L  // Have libstdc++11
 #else
     Receiver_()


### PR DESCRIPTION
Note: This PR is one of 3 options that provide the same functionality in different ways. See #114 for more details