### PR TITLE
fix: template specializations in ArtnetWiFi.h cause multiple definition linker errors in multi-file C++ projects (v0.9.1)

### DIFF
--- a/ArtnetETH.h
+++ b/ArtnetETH.h
@@ -41,25 +41,25 @@ struct MacAddress<ETHClass>
 };
 
 template <>
-IPAddress getLocalIP<ETHUdp>()
+inline IPAddress getLocalIP<ETHUdp>()
 {
     return LocalIP<ETHClass>::get(ETH);
 }
 
 template <>
-IPAddress getSubnetMask<ETHUdp>()
+inline IPAddress getSubnetMask<ETHUdp>()
 {
     return SubnetMask<ETHClass>::get(ETH);
 }
 
 template <>
-void getMacAddress<ETHUdp>(uint8_t mac[6])
+inline void getMacAddress<ETHUdp>(uint8_t mac[6])
 {
     MacAddress<ETHClass>::get(ETH, mac);
 }
 
 template <>
-bool isNetworkReady<ETHUdp>()
+inline bool isNetworkReady<ETHUdp>()
 {
     return true;
 }

--- a/ArtnetEther.h
+++ b/ArtnetEther.h
@@ -40,25 +40,25 @@ struct MacAddress<EthernetClass>
 };
 
 template <>
-IPAddress getLocalIP<EthernetUDP>()
+inline IPAddress getLocalIP<EthernetUDP>()
 {
     return LocalIP<EthernetClass>::get(Ethernet);
 }
 
 template <>
-IPAddress getSubnetMask<EthernetUDP>()
+inline IPAddress getSubnetMask<EthernetUDP>()
 {
     return SubnetMask<EthernetClass>::get(Ethernet);
 }
 
 template <>
-void getMacAddress<EthernetUDP>(uint8_t mac[6])
+inline void getMacAddress<EthernetUDP>(uint8_t mac[6])
 {
     MacAddress<EthernetClass>::get(Ethernet, mac);
 }
 
 template <>
-bool isNetworkReady<EthernetUDP>()
+inline bool isNetworkReady<EthernetUDP>()
 {
     return true;
 }

--- a/ArtnetEtherENC.h
+++ b/ArtnetEtherENC.h
@@ -40,25 +40,25 @@ struct MacAddress<UIPEthernetClass>
 };
 
 template <>
-IPAddress getLocalIP<EthernetUDP>()
+inline IPAddress getLocalIP<EthernetUDP>()
 {
     return LocalIP<UIPEthernetClass>::get(Ethernet);
 }
 
 template <>
-IPAddress getSubnetMask<EthernetUDP>()
+inline IPAddress getSubnetMask<EthernetUDP>()
 {
     return SubnetMask<UIPEthernetClass>::get(Ethernet);
 }
 
 template <>
-void getMacAddress<EthernetUDP>(uint8_t mac[6])
+inline void getMacAddress<EthernetUDP>(uint8_t mac[6])
 {
     MacAddress<UIPEthernetClass>::get(Ethernet, mac);
 }
 
 template <>
-bool isNetworkReady<EthernetUDP>()
+inline bool isNetworkReady<EthernetUDP>()
 {
     return true;
 }

--- a/ArtnetNativeEther.h
+++ b/ArtnetNativeEther.h
@@ -40,25 +40,25 @@ struct MacAddress<EthernetClass>
 };
 
 template <>
-IPAddress getLocalIP<EthernetUDP>()
+inline IPAddress getLocalIP<EthernetUDP>()
 {
     return LocalIP<EthernetClass>::get(Ethernet);
 }
 
 template <>
-IPAddress getSubnetMask<EthernetUDP>()
+inline IPAddress getSubnetMask<EthernetUDP>()
 {
     return SubnetMask<EthernetClass>::get(Ethernet);
 }
 
 template <>
-void getMacAddress<EthernetUDP>(uint8_t mac[6])
+inline void getMacAddress<EthernetUDP>(uint8_t mac[6])
 {
     MacAddress<EthernetClass>::get(Ethernet, mac);
 }
 
 template <>
-bool isNetworkReady<EthernetUDP>()
+inline bool isNetworkReady<EthernetUDP>()
 {
     return true;
 }

--- a/ArtnetWiFi.h
+++ b/ArtnetWiFi.h
@@ -99,25 +99,25 @@ struct IsNetworkReady<ArtnetWiFiClass>
 };
 
 template <>
-IPAddress getLocalIP<WiFiUDP>()
+inline IPAddress getLocalIP<WiFiUDP>()
 {
     return LocalIP<ArtnetWiFiClass>::get(WiFi);
 }
 
 template <>
-IPAddress getSubnetMask<WiFiUDP>()
+inline IPAddress getSubnetMask<WiFiUDP>()
 {
     return SubnetMask<ArtnetWiFiClass>::get(WiFi);
 }
 
 template <>
-void getMacAddress<WiFiUDP>(uint8_t mac[6])
+inline void getMacAddress<WiFiUDP>(uint8_t mac[6])
 {
     MacAddress<ArtnetWiFiClass>::get(WiFi, mac);
 }
 
 template <>
-bool isNetworkReady<WiFiUDP>()
+inline bool isNetworkReady<WiFiUDP>()
 {
     return IsNetworkReady<ArtnetWiFiClass>::get(WiFi);
 }


### PR DESCRIPTION
Hello again,

I've been running into a linker issue, when using the 0.9.1 in my C++ project. 

Below is the analysis of Claude Code, please take it with a grain of salt, it could be garbage and I'm doing it wrong. If so, my apologies. But, adding the inline keywords fixes the issue for my build. 

Thank you for a cool library!

---
The template specializations for `getLocalIP`, `getSubnetMask`, `getMacAddress`, and `isNetworkReady` in `ArtnetWiFi.h` (lines 102, 108, 114, 120) (and the other .h files) are missing the `inline` keyword, causing ODR (One Definition Rule) violations when the header is included in multiple translation units.

**Error Example:**
```
multiple definition of `IPAddress art_net::getLocalIP<WiFiUDP>()'
```

**Affected Code (ArtnetWiFi.h):**
```cpp
template <>
IPAddress getLocalIP<WiFiUDP>()  // <-- Missing 'inline'
{
    return LocalIP<ArtnetWiFiClass>::get(WiFi);
}
```

Fix: Add inline keyword to all four template specializations (lines 102, 108, 114, 120):

```cpp
template <>
inline IPAddress getLocalIP<WiFiUDP>()
{
    return LocalIP<ArtnetWiFiClass>::get(WiFi);
}
```

**Why this happens:**
Simple Arduino sketches (single .ino file) work fine because they compile to one translation unit
Multi-file C++ projects fail because the template specializations get compiled into multiple object files
The linker sees duplicate symbols and fails


**Impact of fix:**
✅ No behavior change for existing working code
✅ No performance impact
✅ Fixes multi-file C++ projects (PlatformIO, Arduino with multiple .cpp files)
✅ Standard C++ practice for header-only template specializations
